### PR TITLE
Update glium to 0.30 and bump own version number.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuklear-backend-glium"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Serhii Plyhun <snuk188@gmail.com>"]
 keywords = ["widgets", "gui", "interface", "graphics", "glium"]
 description = "A glium drawing backend for Rust wrapper for Nuklear 2D GUI library"
@@ -16,6 +16,6 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "~0.3"
-glium = "~0.24"
+glium = "~0.30"
 nuklear-rust = "~0.6"
 


### PR DESCRIPTION
Updated glium to the newest version which is then compatible with code from [https://github.com/glium/glium/tree/master/examples](https://github.com/glium/glium/tree/master/examples).
The glium-backend example code which is linked in the [https://github.com/snuk182/nuklear-rust](https://github.com/snuk182/nuklear-rust) crate is now outdated, though.